### PR TITLE
update => patch for nginx 1.25.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,6 @@
 
 ## Nginx
 
-### nginx.patch
-* Add HTTP2 HPACK Encoding Support.
-* Add Dynamic TLS Record Support.
-
-Require: Nginx 1.25.0 (this version only)
-
-Test pass: 1.25.0
-
-Since `Nginx` 1.25.1, HPACK encoding will not support because the HTTP/2 server push support has been removed.
-
 ### nginx_dynamic_tls_records.patch
 * Add Dynamic TLS Record Support.
 
@@ -24,7 +14,7 @@ Test pass: 1.25.1
 * Repack it because "patch unexpectedly ends in middle of line".
     - Thanks [@CarterLi](https://github.com/kn007/patch/issues/5)
 
-Test pass: 1.25.0
+Test pass: 1.25.1
 
 ### Enable_BoringSSL_OCSP.patch
 * For BoringSSL support OCSP stapling.
@@ -35,13 +25,15 @@ Test pass: 1.25.0
 
 Test pass: 1.23.4
 
-### nginx_for_1.23.4.patch (Deprecated)
+### nginx.patch (Discontinued)
 * Add HTTP2 HPACK Encoding Support.
 * Add Dynamic TLS Record Support.
 
-Require: Nginx version below 1.25.0
+Require: Nginx 1.25.0 (this version only)
 
-Test pass: 1.23.4
+Test pass: 1.25.0
+
+Since `Nginx` 1.25.1, HPACK encoding will not support because the HTTP/2 server push support has been removed.
 
 ### nginx_with_quic.patch (Discontinued)
 * Add HTTP3(QUIC) Support.
@@ -54,6 +46,14 @@ Require: Nginx 1.21.4 or later.
 Test pass: 1.23.3 with [cloudflare/quiche@c9311a1](https://github.com/cloudflare/quiche/tree/c9311a18910c0277867c34c0acc4a9711b50b913)
 
 <b>Check your modules when build failed.</b>
+
+### nginx_for_1.23.4.patch (Deprecated)
+* Add HTTP2 HPACK Encoding Support.
+* Add Dynamic TLS Record Support.
+
+Require: Nginx version below 1.25.0
+
+Test pass: 1.23.4
 
 ### nginx_with_quic_for_1.19.7_full.patch (Deprecated)
 * Add HTTP3(QUIC) Support.
@@ -95,7 +95,7 @@ Test pass: 1.17.9 with [cloudflare/quiche@9a8b3b](https://github.com/cloudflare/
 * Add BoringSSL's Equal Preference Support.
 * Add ChaCha20-Poly1305 Draft Version Support.
 
-Test pass: 1.1.1s
+Test pass: 1.1.1u
 
 ### ffmpeg-let-rtmp-flv-support-hevc-h265-opus.patch
 * FLV/RTMP Extensions For FFmpeg.

--- a/README.md
+++ b/README.md
@@ -6,11 +6,36 @@
 * Add HTTP2 HPACK Encoding Support.
 * Add Dynamic TLS Record Support.
 
-Require: Nginx 1.25.0 or later
+Require: Nginx 1.25.0 (this version only)
 
 Test pass: 1.25.0
 
-### nginx_for_1.23.4.patch
+Since `Nginx` 1.25.1, HPACK encoding will not support because the HTTP/2 server push support has been removed.
+
+### nginx_dynamic_tls_records.patch
+* Add Dynamic TLS Record Support.
+
+Require: Nginx 1.25.1
+
+Test pass: 1.25.1
+
+### use_openssl_md5_sha1.patch
+* Use the OpenSSL library instead of the Nginx original function.
+* Repack it because "patch unexpectedly ends in middle of line".
+    - Thanks [@CarterLi](https://github.com/kn007/patch/issues/5)
+
+Test pass: 1.25.0
+
+### Enable_BoringSSL_OCSP.patch
+* For BoringSSL support OCSP stapling.
+    - Using "ssl_stapling_file" to support.
+    - Only "ssl_stapling_file" with single cert is supported.
+    - Auto-rebuild OCSP stapling file with shell and atd(at cron), you can read this [article](https://kn007.net/topics/let-nginx-support-ocsp-stapling-when-using-boringssl/)(Maybe you need a translation tool).
+    - Thanks [@CarterLi](https://github.com/kn007/patch/issues/4).
+
+Test pass: 1.23.4
+
+### nginx_for_1.23.4.patch (Deprecated)
 * Add HTTP2 HPACK Encoding Support.
 * Add Dynamic TLS Record Support.
 
@@ -29,22 +54,6 @@ Require: Nginx 1.21.4 or later.
 Test pass: 1.23.3 with [cloudflare/quiche@c9311a1](https://github.com/cloudflare/quiche/tree/c9311a18910c0277867c34c0acc4a9711b50b913)
 
 <b>Check your modules when build failed.</b>
-
-### use_openssl_md5_sha1.patch
-* Use the OpenSSL library instead of the Nginx original function.
-* Repack it because "patch unexpectedly ends in middle of line".
-    - Thanks [@CarterLi](https://github.com/kn007/patch/issues/5)
-
-Test pass: 1.25.0
-
-### Enable_BoringSSL_OCSP.patch
-* For BoringSSL support OCSP stapling.
-    - Using "ssl_stapling_file" to support.
-    - Only "ssl_stapling_file" with single cert is supported.
-    - Auto-rebuild OCSP stapling file with shell and atd(at cron), you can read this [article](https://kn007.net/topics/let-nginx-support-ocsp-stapling-when-using-boringssl/)(Maybe you need a translation tool).
-    - Thanks [@CarterLi](https://github.com/kn007/patch/issues/4).
-
-Test pass: 1.23.4
 
 ### nginx_with_quic_for_1.19.7_full.patch (Deprecated)
 * Add HTTP3(QUIC) Support.

--- a/nginx_dynamic_tls_records.patch
+++ b/nginx_dynamic_tls_records.patch
@@ -1,0 +1,254 @@
+What we do now:
+We use a static record size of 4K. This gives a good balance of latency and
+throughput.
+
+Optimize latency:
+By initialy sending small (1 TCP segment) sized records, we are able to avoid
+HoL blocking of the first byte. This means TTFB is sometime lower by a whole
+RTT.
+
+Optimizing throughput:
+By sending increasingly larger records later in the connection, when HoL is not
+a problem, we reduce the overhead of TLS record (29 bytes per record with
+GCM/CHACHA-POLY).
+
+Logic:
+Start each connection with small records (1369 byte default, change with
+ssl_dyn_rec_size_lo). After a given number of records (40, change with
+ssl_dyn_rec_threshold) start sending larger records (4229, ssl_dyn_rec_size_hi).
+Eventually after the same number of records, start sending the largest records
+(ssl_buffer_size).
+In case the connection idles for a given amount of time (1s,
+ssl_dyn_rec_timeout), the process repeats itself (i.e. begin sending small
+records again).
+
+
+diff --color -uNr a/src/event/ngx_event_openssl.c b/src/event/ngx_event_openssl.c
+--- a/src/event/ngx_event_openssl.c	2023-06-13 23:08:10.000000000 +0800
++++ b/src/event/ngx_event_openssl.c	2023-06-14 15:43:05.834243714 +0800
+@@ -1674,6 +1674,7 @@
+ 
+     sc->buffer = ((flags & NGX_SSL_BUFFER) != 0);
+     sc->buffer_size = ssl->buffer_size;
++    sc->dyn_rec = ssl->dyn_rec;
+ 
+     sc->session_ctx = ssl->ctx;
+ 
+@@ -2645,6 +2646,41 @@
+ 
+     for ( ;; ) {
+ 
++        /* Dynamic record resizing:
++           We want the initial records to fit into one TCP segment
++           so we don't get TCP HoL blocking due to TCP Slow Start.
++           A connection always starts with small records, but after
++           a given amount of records sent, we make the records larger
++           to reduce header overhead.
++           After a connection has idled for a given timeout, begin
++           the process from the start. The actual parameters are
++           configurable. If dyn_rec_timeout is 0, we assume dyn_rec is off. */
++
++        if (c->ssl->dyn_rec.timeout > 0 ) {
++
++            if (ngx_current_msec - c->ssl->dyn_rec_last_write >
++                c->ssl->dyn_rec.timeout)
++            {
++                buf->end = buf->start + c->ssl->dyn_rec.size_lo;
++                c->ssl->dyn_rec_records_sent = 0;
++
++            } else {
++                if (c->ssl->dyn_rec_records_sent >
++                    c->ssl->dyn_rec.threshold * 2)
++                {
++                    buf->end = buf->start + c->ssl->buffer_size;
++
++                } else if (c->ssl->dyn_rec_records_sent >
++                           c->ssl->dyn_rec.threshold)
++                {
++                    buf->end = buf->start + c->ssl->dyn_rec.size_hi;
++
++                } else {
++                    buf->end = buf->start + c->ssl->dyn_rec.size_lo;
++                }
++            }
++        }
++
+         while (in && buf->last < buf->end && send < limit) {
+             if (in->buf->last_buf || in->buf->flush) {
+                 flush = 1;
+@@ -2784,6 +2820,9 @@
+ 
+     if (n > 0) {
+ 
++        c->ssl->dyn_rec_records_sent++;
++        c->ssl->dyn_rec_last_write = ngx_current_msec;
++
+         if (c->ssl->saved_read_handler) {
+ 
+             c->read->handler = c->ssl->saved_read_handler;
+diff --color -uNr a/src/event/ngx_event_openssl.h b/src/event/ngx_event_openssl.h
+--- a/src/event/ngx_event_openssl.h	2023-06-13 23:08:10.000000000 +0800
++++ b/src/event/ngx_event_openssl.h	2023-06-14 15:43:05.834243714 +0800
+@@ -86,10 +86,19 @@
+ typedef struct ngx_ssl_ocsp_s  ngx_ssl_ocsp_t;
+ 
+ 
++typedef struct {
++    ngx_msec_t                  timeout;
++    ngx_uint_t                  threshold;
++    size_t                      size_lo;
++    size_t                      size_hi;
++} ngx_ssl_dyn_rec_t;
++
++
+ struct ngx_ssl_s {
+     SSL_CTX                    *ctx;
+     ngx_log_t                  *log;
+     size_t                      buffer_size;
++    ngx_ssl_dyn_rec_t           dyn_rec;
+ };
+ 
+ 
+@@ -128,6 +137,10 @@
+     unsigned                    in_ocsp:1;
+     unsigned                    early_preread:1;
+     unsigned                    write_blocked:1;
++
++    ngx_ssl_dyn_rec_t           dyn_rec;
++    ngx_msec_t                  dyn_rec_last_write;
++    ngx_uint_t                  dyn_rec_records_sent;
+ };
+ 
+ 
+@@ -137,7 +150,7 @@
+ #define NGX_SSL_DFLT_BUILTIN_SCACHE  -5
+ 
+ 
+-#define NGX_SSL_MAX_SESSION_SIZE  4096
++#define NGX_SSL_MAX_SESSION_SIZE  16384
+ 
+ typedef struct ngx_ssl_sess_id_s  ngx_ssl_sess_id_t;
+ 
+diff --color -uNr a/src/http/modules/ngx_http_ssl_module.c b/src/http/modules/ngx_http_ssl_module.c
+--- a/src/http/modules/ngx_http_ssl_module.c	2023-06-13 23:08:10.000000000 +0800
++++ b/src/http/modules/ngx_http_ssl_module.c	2023-06-14 15:43:05.834243714 +0800
+@@ -290,6 +290,41 @@
+       offsetof(ngx_http_ssl_srv_conf_t, reject_handshake),
+       NULL },
+ 
++    { ngx_string("ssl_dyn_rec_enable"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_flag_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_enable),
++      NULL },
++
++    { ngx_string("ssl_dyn_rec_timeout"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_msec_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_timeout),
++      NULL },
++
++    { ngx_string("ssl_dyn_rec_size_lo"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_size_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_size_lo),
++      NULL },
++
++    { ngx_string("ssl_dyn_rec_size_hi"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_size_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_size_hi),
++      NULL },
++
++    { ngx_string("ssl_dyn_rec_threshold"),
++      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
++      ngx_conf_set_num_slot,
++      NGX_HTTP_SRV_CONF_OFFSET,
++      offsetof(ngx_http_ssl_srv_conf_t, dyn_rec_threshold),
++      NULL },
++
+       ngx_null_command
+ };
+ 
+@@ -629,6 +664,11 @@
+     sscf->ocsp_cache_zone = NGX_CONF_UNSET_PTR;
+     sscf->stapling = NGX_CONF_UNSET;
+     sscf->stapling_verify = NGX_CONF_UNSET;
++    sscf->dyn_rec_enable = NGX_CONF_UNSET;
++    sscf->dyn_rec_timeout = NGX_CONF_UNSET_MSEC;
++    sscf->dyn_rec_size_lo = NGX_CONF_UNSET_SIZE;
++    sscf->dyn_rec_size_hi = NGX_CONF_UNSET_SIZE;
++    sscf->dyn_rec_threshold = NGX_CONF_UNSET_UINT;
+ 
+     return sscf;
+ }
+@@ -694,6 +734,20 @@
+     ngx_conf_merge_str_value(conf->stapling_responder,
+                          prev->stapling_responder, "");
+ 
++    ngx_conf_merge_value(conf->dyn_rec_enable, prev->dyn_rec_enable, 0);
++    ngx_conf_merge_msec_value(conf->dyn_rec_timeout, prev->dyn_rec_timeout,
++                             1000);
++    /* Default sizes for the dynamic record sizes are defined to fit maximal
++       TLS + IPv6 overhead in a single TCP segment for lo and 3 segments for hi:
++       1369 = 1500 - 40 (IP) - 20 (TCP) - 10 (Time) - 61 (Max TLS overhead) */
++    ngx_conf_merge_size_value(conf->dyn_rec_size_lo, prev->dyn_rec_size_lo,
++                             1369);
++    /* 4229 = (1500 - 40 - 20 - 10) * 3  - 61 */
++    ngx_conf_merge_size_value(conf->dyn_rec_size_hi, prev->dyn_rec_size_hi,
++                             4229);
++    ngx_conf_merge_uint_value(conf->dyn_rec_threshold, prev->dyn_rec_threshold,
++                             40);
++
+     conf->ssl.log = cf->log;
+ 
+     if (conf->certificates) {
+@@ -890,6 +944,28 @@
+         return NGX_CONF_ERROR;
+     }
+ 
++    if (conf->dyn_rec_enable) {
++        conf->ssl.dyn_rec.timeout = conf->dyn_rec_timeout;
++        conf->ssl.dyn_rec.threshold = conf->dyn_rec_threshold;
++
++        if (conf->buffer_size > conf->dyn_rec_size_lo) {
++            conf->ssl.dyn_rec.size_lo = conf->dyn_rec_size_lo;
++
++        } else {
++            conf->ssl.dyn_rec.size_lo = conf->buffer_size;
++        }
++
++        if (conf->buffer_size > conf->dyn_rec_size_hi) {
++            conf->ssl.dyn_rec.size_hi = conf->dyn_rec_size_hi;
++
++        } else {
++            conf->ssl.dyn_rec.size_hi = conf->buffer_size;
++        }
++
++    } else {
++        conf->ssl.dyn_rec.timeout = 0;
++    }
++
+     return NGX_CONF_OK;
+ }
+ 
+diff --color -uNr a/src/http/modules/ngx_http_ssl_module.h b/src/http/modules/ngx_http_ssl_module.h
+--- a/src/http/modules/ngx_http_ssl_module.h	2023-06-13 23:08:10.000000000 +0800
++++ b/src/http/modules/ngx_http_ssl_module.h	2023-06-14 15:43:38.264102815 +0800
+@@ -62,6 +62,12 @@
+     ngx_flag_t                      stapling_verify;
+     ngx_str_t                       stapling_file;
+     ngx_str_t                       stapling_responder;
++
++    ngx_flag_t                      dyn_rec_enable;
++    ngx_msec_t                      dyn_rec_timeout;
++    size_t                          dyn_rec_size_lo;
++    size_t                          dyn_rec_size_hi;
++    ngx_uint_t                      dyn_rec_threshold;
+ } ngx_http_ssl_srv_conf_t;
+ 
+ 

--- a/rimworld.mods
+++ b/rimworld.mods
@@ -783,6 +783,9 @@ Mods:
 - Id: nomadrw.turretvanillaretexturerestyle
   Name: Turret Vanilla Retexture and Restyle
   SteamWorkshopId: 2980467701
+- Id: mosi.bridgecolor2
+  Name: 'Bridge Color Tweak 2: Colorful Boogaloo'
+  SteamWorkshopId: 2985505036
 - Id: iexist.biotech.morebandwidth
   Name: Bandwidth Enhancer
   SteamWorkshopId: 2888505789

--- a/rimworld.mods
+++ b/rimworld.mods
@@ -99,6 +99,9 @@ Mods:
 - Id: tenthwit.apparel
   Name: Retextured Apparel
   SteamWorkshopId: 2042613316
+- Id: tied.parkaretex
+  Name: Parka Retexture
+  SteamWorkshopId: 2984307648
 - Id: tenthwit.sculptures
   Name: Retextured Sculptures
   SteamWorkshopId: 2045252395
@@ -267,6 +270,9 @@ Mods:
 - Id: brrainz.justignoremepassing
   Name: Just Ignore Me Passing
   SteamWorkshopId: 1231617602
+- Id: doll.nevergeneraterelations
+  Name: Never Generate Relations
+  SteamWorkshopId: 2891797130
 - Id: mlie.allmemoriesfade
   Name: All Memories Fade
   SteamWorkshopId: 2800155563
@@ -477,9 +483,6 @@ Mods:
 - Id: haecriver.injuredcarry
   Name: Injured Carry
   SteamWorkshopId: 2413690575
-- Id: dvs.norandomrelations
-  Name: No Random Relations
-  SteamWorkshopId: 2583377522
 - Id: alien.milkablemuffalo
   Name: Milkable Muffalo
   SteamWorkshopId: 2019852283
@@ -888,6 +891,9 @@ Mods:
 - Id: chen.outdoorlighting.zh
   Name: Outdoor Lighting-zh
   SteamWorkshopId: 2902036198
+- Id: gwinnbleidd.mothballedanddeadpawns
+  Name: 'Better GC: Mothballed and World Pawns'
+  SteamWorkshopId: 2982026860
 - Id: taranchuk.performanceoptimizer
   Name: Performance Optimizer
   SteamWorkshopId: 2664723367

--- a/rimworld.mods
+++ b/rimworld.mods
@@ -897,6 +897,9 @@ Mods:
 - Id: gwinnbleidd.mothballedanddeadpawns
   Name: 'Better GC: Mothballed and World Pawns'
   SteamWorkshopId: 2982026860
+- Id: trinity.runtimegcfixed
+  Name: RuntimeGC [1.4]
+  SteamWorkshopId: 2983911897
 - Id: taranchuk.performanceoptimizer
   Name: Performance Optimizer
   SteamWorkshopId: 2664723367


### PR DESCRIPTION
- Since `Nginx` 1.25.1, HPACK encoding will not support because the HTTP/2 server push support has been removed.